### PR TITLE
Improve website configration and SEO

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -22,8 +22,8 @@ title: EECS 493
 favicon: https://eecs493staff.github.io/eecs493.org/assets/images/eecs493favicon.ico
 email:
 description: >- # this means to ignore newlines until "baseurl:"
-url: "https://eecs493staff.github.io/eecs493.org" # the base hostname & protocol
-baseurl: "" # the subpath of your site, e.g. /blog
+url: "https://eecs493staff.github.io" # the base hostname & protocol
+baseurl: "/eecs493.org" # the subpath of your site, e.g. /blog
 
 # Build settings
 github: [metadata]

--- a/docs/eecs493.org/index.html
+++ b/docs/eecs493.org/index.html
@@ -15,6 +15,7 @@
 
   <title>EECS 493</title>
   <link rel="shortcut icon" type="image/x-icon" href="assets/images/eecs493favicon.ico">
+  <link rel="canonical" href="https://eecs493staff.github.io/eecs493.org/">
 
   <!-- Fomantic UI CSS library
        https://fomantic-ui.com/introduction/getting-started.html#using-a-cdn-provider -->

--- a/docs/google4e956b4549cf3ec3.html
+++ b/docs/google4e956b4549cf3ec3.html
@@ -1,0 +1,1 @@
+google-site-verification: google4e956b4549cf3ec3.html

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <!-- Redirect to the subfolder immediately -->
+    <meta http-equiv="refresh" content="0; url=/eecs493.org/" />
+
+    <!-- Canonical link to tell Google the "true" URL of your site -->
+    <link rel="canonical" href="https://eecs493staff.github.io/eecs493.org/" />
+
+    <title>EECS 493: User Interface Development</title>
+  </head>
+  <body>
+    <!-- Fallback link for browsers that don’t support meta refresh -->
+    <p>Redirecting... If you aren't redirected, <a href="/eecs493.org/">click here</a>.</p>
+  </body>
+</html>


### PR DESCRIPTION
## Issue

Attempted to fix the Google search issue (#3), i.e. the course website has an incorrect/default title/favicon on Google search.

## Major Changes

1. Updated `url` in `_config.yaml`.
2. Added a redirect `index.html` file in the root of `docs/`.

## Explanation

Google initially crawls the root URL (`https://eecs493staff.github.io/`). Without the redirect, it sees GitHub’s default page (with the title "GitHub Pages") because our site is hidden in a subfolder. The redirect ensures Googlebot follows the meta refresh and indexes the subfolder’s `index.html`, which contains our custom title and favicon. The canonical link reinforces that the subfolder is the "true" version of the site, improving SEO.

However, this redirect will add a slight delay (though it’s instant) when loading (the baseurl of) the website. There are 2 alternative, and likely better solution to this issue:

1. Move all contents in the `eecs493.org/` subfolder to the `docs/` folder. This requires significant changes to the directory structure and the links in the html files.
2. Purchase a custom domain, as stated in #12.

## Remark

Google might take days or weeks to re-index, so the updates may take a while to show their effects.
